### PR TITLE
[feat] Support action in rule

### DIFF
--- a/src/airphin/constants.py
+++ b/src/airphin/constants.py
@@ -4,6 +4,8 @@ class TOKEN:
     IMPORT: str = "import"
     COMMA: str = ","
     POINT: str = "."
+    STRING: str = "str"
+    CODE: str = "code"
 
 
 class KEYWORD:
@@ -22,10 +24,21 @@ class REGEXP:
 class CONFIG:
     """Constants config file for airphin."""
 
-    MODULE: str = "module"
-    MIGRATION: str = "migration"
-    DESTINATION: str = "dest"
-    SOURCE: str = "src"
-    PARAMETER: str = "parameter"
-    DEFAULT: str = "default"
     EXAMPLE: str = "examples"
+
+    MIGRATION: str = "migration"
+    MODULE: str = "module"
+    PARAMETER: str = "parameter"
+
+    ACTION: str = "action"
+    SOURCE: str = "src"
+    DESTINATION: str = "dest"
+
+    KW_REPLACE: str = "replace"
+    KW_ADD: str = "add"
+    KW_REMOVE: str = "remove"
+
+    ARGUMENT: str = "arg"
+    DEFAULT: str = "default"
+    TYPE: str = "type"
+    VALUE: str = "value"

--- a/src/airphin/core/transformer/route.py
+++ b/src/airphin/core/transformer/route.py
@@ -18,7 +18,6 @@ import warnings
 from typing import Set, Union
 
 import libcst as cst
-import libcst.matchers as m
 from libcst import BaseExpression, FlattenSentinel, RemovalSentinel
 from libcst.metadata import PositionProvider, QualifiedName, QualifiedNameProvider
 
@@ -27,10 +26,11 @@ from airphin.core.transformer.imports import ImportTransformer
 from airphin.core.transformer.operators import OpTransformer
 
 
-class Transformer(m.MatcherDecoratableTransformer):
+class Transformer(cst.CSTTransformer):
     """CST Transformer route class from airflow to dolphinscheduler-sdk-python.
 
-    The main class to call each rules to convert, just like a router.
+    The main class to call each rules to convert, just like a router, currently will route to `imports` and
+    `operators` transformer.
     """
 
     METADATA_DEPENDENCIES = (

--- a/src/airphin/rules/core/dagContext.yaml
+++ b/src/airphin/rules/core/dagContext.yaml
@@ -3,16 +3,18 @@ description: The configuration for converting airflow.DAG context to pydolphinsc
 
 migration:
   module:
-    src: airflow.DAG
-    dest: pydolphinscheduler.core.process_definition.ProcessDefinition
+    - action: replace
+      src: airflow.DAG
+      dest: pydolphinscheduler.core.process_definition.ProcessDefinition
   parameter:
-    - src: dag_id
+    - action: replace
+      src: dag_id
       dest: name
-    - src: description
-      dest: description
-    - src: start_date
+    - action: replace
+      src: start_date
       dest: start_time
-    - src: schedule_interval
+    - action: replace
+      src: schedule_interval
       dest: schedule
 
 examples:

--- a/src/airphin/rules/operators/BashOperator.yaml
+++ b/src/airphin/rules/operators/BashOperator.yaml
@@ -3,14 +3,17 @@ description: The configuration for converting Airflow BashOperator to DolphinSch
 
 migration:
   module:
-    src: 
-      - airflow.operators.bash.BashOperator
-      - airflow.operators.bash_operator.BashOperator
-    dest: pydolphinschsduler.tasks.shell.Shell
+    - action: replace
+      src:
+        - airflow.operators.bash.BashOperator
+        - airflow.operators.bash_operator.BashOperator
+      dest: pydolphinschsduler.tasks.shell.Shell
   parameter:
-    - src: task_id
+    - action: replace
+      src: task_id
       dest: name
-    - src: bash_command
+    - action: replace
+      src: bash_command
       dest: command
 
 examples:

--- a/src/airphin/rules/operators/DummyOperator.yaml
+++ b/src/airphin/rules/operators/DummyOperator.yaml
@@ -3,14 +3,18 @@ description: The configuration for converting Airflow DummyOperator to DolphinSc
 
 migration:
   module:
-    src: airflow.operators.dummy_operator.DummyOperator
-    dest: pydolphinschsduler.tasks.shell.Shell
+    - action: replace
+      src: airflow.operators.dummy_operator.DummyOperator
+      dest: pydolphinschsduler.tasks.shell.Shell
   parameter:
-    - src: task_id
+    - action: replace
+      src: task_id
       dest: name
-    - src: bash_command
-      dest: command
-      default: echo 'Airflow DummyOperator'
+    - action: add
+      arg: command
+      default: 
+        type: str
+        value: "echo 'Airflow DummyOperator'"
 
 examples:
   dummy:

--- a/src/airphin/rules/operators/PythonOperator.yaml
+++ b/src/airphin/rules/operators/PythonOperator.yaml
@@ -3,12 +3,15 @@ description: The configuration for converting Airflow PythonOperator to DolphinS
 
 migration:
   module:
-    src: airflow.operators.python_operator.PythonOperator
-    dest: pydolphinschsduler.tasks.python.Python
+    - action: replace
+      src: airflow.operators.python_operator.PythonOperator
+      dest: pydolphinschsduler.tasks.python.Python
   parameter:
-    - src: task_id
+    - action: replace
+      src: task_id
       dest: name
-    - src: python_callable
+    - action: replace
+      src: python_callable
       dest: definition
 
 examples:

--- a/src/airphin/rules/operators/SparkSqlOperator.yaml
+++ b/src/airphin/rules/operators/SparkSqlOperator.yaml
@@ -3,12 +3,15 @@ description: The configuration for converting Airflow SparkSqlOperator to Dolphi
 
 migration:
   module:
-    src: airflow.operators.spark_sql_operator.SparkSqlOperator
-    dest: pydolphinschsduler.tasks.sql.Sql
+    - action: replace
+      src: airflow.operators.spark_sql_operator.SparkSqlOperator
+      dest: pydolphinschsduler.tasks.sql.Sql
   parameter:
-    - src: task_id
+    - action: replace
+      src: task_id
       dest: name
-    - src: conn_id
+    - action: replace
+      src: conn_id
       dest: datasource_name
 
 examples:

--- a/tests/rules/test_example.py
+++ b/tests/rules/test_example.py
@@ -23,8 +23,8 @@ def test_rules_example(rule_ex: Path) -> None:
     for name, case in cases.items():
         src = case.get(CONFIG.SOURCE)
         dest = case.get(CONFIG.DESTINATION)
-        assert dest == runner.with_str(
-            src
+        assert (
+            runner.with_str(src) == dest
         ), f"Migrate test case {rule_ex.stem}.{name} failed."
 
 

--- a/tests/rules/test_rules.py
+++ b/tests/rules/test_rules.py
@@ -1,71 +1,109 @@
+from typing import Any, Dict
+
+from airphin.constants import CONFIG
+from airphin.core.rules.config import Config
 from airphin.core.rules.loader import path_rule
 from airphin.utils.file import read_yaml
 
 ROOT_MUST_HAVE_ATTR = ["name", "description", "migration", "examples"]
 EXAMPLES_MUST_HAVE_ATTR = ["description", "src", "dest"]
 
-
 all_rules = [path for path in path_rule.glob("**/*") if path.is_file()]
 
 
-def test_rules_suffix() -> None:
+def test_suffix() -> None:
     for rule in all_rules:
         assert rule.suffix == ".yaml", f"Rule file {rule} must have suffix .yaml"
 
 
-def test_rule_file_must_attr() -> None:
+def test_file_must_have_attr() -> None:
     for rule in all_rules:
         content = read_yaml(rule)
         for attr in ROOT_MUST_HAVE_ATTR:
             assert attr in content, f"Rule file {rule} must have attribute {attr}"
 
 
-def test_rules_module_pair() -> None:
+def module_add_rm(action: Dict[str, Any]) -> bool:
+    return CONFIG.MODULE in action
+
+
+def test_module_action_type() -> None:
+    for rule in all_rules:
+        content = read_yaml(rule)
+        migration = content["migration"]
+
+        # will raise error if more than one action in :func:``get_module_action``
+        Config.get_module_action(migration, CONFIG.KW_REPLACE)
+
+        add = Config.get_module_action(migration, CONFIG.KW_ADD)
+        if add:
+            assert isinstance(
+                add[CONFIG.MODULE], (str, list)
+            ), f"Rule file {rule} `add` action value must with type str or list."
+
+        remove = Config.get_module_action(migration, CONFIG.KW_REMOVE)
+        if remove:
+            assert isinstance(
+                remove[CONFIG.MODULE], (str, list)
+            ), f"Rule file {rule} `remove` action value must with type str or list."
+
+
+def test_module_action_attr() -> None:
+    for rule in all_rules:
+        content = read_yaml(rule)
+        actions = content["migration"]["module"]
+        for action in actions:
+            assert (
+                CONFIG.ACTION in action
+            ), "Rule {rule} module each item must have attr action."
+            if action[CONFIG.ACTION] in {CONFIG.KW_REMOVE, CONFIG.KW_ADD}:
+                assert module_add_rm(
+                    action
+                ), "Rule {rule} module action `remove` or `add` do not have must exits attr."
+            elif action[CONFIG.ACTION] == CONFIG.KW_REPLACE:
+                assert action_replace(
+                    action
+                ), "Rule {rule} parameter action `replace` do not have must exits attr."
+            else:
+                raise ValueError(
+                    "Rule {rule} parameter action must with specific value."
+                )
+
+
+def test_module_action_replace() -> None:
     for rule in all_rules:
         content = read_yaml(rule)
         migration = content["migration"]
         if "module" in migration:
-            module = migration["module"]
+            replace = Config.get_module_action(migration, CONFIG.KW_REPLACE)
             assert (
-                "src" in module
+                "src" in replace
             ), f"Rule file {rule} migration.module pair key `src` not exists."
             assert (
-                "dest" in module
+                "dest" in replace
             ), f"Rule file {rule} migration.module pair key `dest` not exists."
 
 
-def test_rules_param_pair() -> None:
-    for rule in all_rules:
-        content = read_yaml(rule)
-        migration = content["migration"]
-        if "parameter" in migration:
-            for params in migration["parameter"]:
-                assert (
-                    "src" in params.keys()
-                ), f"Rule file {rule} migration.parameter pair key `src` not exists."
-                assert (
-                    "dest" in params.keys()
-                ), f"Rule file {rule} migration.parameter pair key `dest` not exists."
-
-
-def test_rules_module_src_list_or_str() -> None:
+def test_module_action_replace_src_list_or_str() -> None:
     for rule in all_rules:
         content = read_yaml(rule)
         migration = content["migration"]
         if "module" in migration:
-            src = migration["module"]["src"]
+            replace = Config.get_module_action(migration, CONFIG.KW_REPLACE)
+            src = replace["src"]
             assert isinstance(
                 src, (list, str)
             ), f"Rule file {rule} migration.module.src must be list or str."
 
 
-def test_rules_module_src_duplicate() -> None:
+def test_module_action_replace_src_duplicate() -> None:
     exists = set()
     for rule in all_rules:
         content = read_yaml(rule)
         migration = content["migration"]
         if "module" in migration:
-            src = migration["module"]["src"]
+            replace = Config.get_module_action(migration, CONFIG.KW_REPLACE)
+            src = replace["src"]
             if isinstance(src, list):
                 for s in src:
                     assert (
@@ -79,7 +117,7 @@ def test_rules_module_src_duplicate() -> None:
                 exists.add(src)
 
 
-def test_rules_example_must_attr() -> None:
+def test_example_must_attr() -> None:
     for rule in all_rules:
         content = read_yaml(rule)
         examples = content["examples"]
@@ -88,3 +126,46 @@ def test_rules_example_must_attr() -> None:
             assert all(
                 attr in example for attr in EXAMPLES_MUST_HAVE_ATTR
             ), f"Rule file {rule} examples missing must have attribute {EXAMPLES_MUST_HAVE_ATTR}"
+
+
+def test_param_action_type() -> None:
+    for rule in all_rules:
+        content = read_yaml(rule)
+        parameter = content["migration"]["parameter"]
+        for params in parameter:
+            assert (
+                CONFIG.ACTION in params
+            ), "Rule {rule} all parameter must have attr action."
+            if params[CONFIG.ACTION] == CONFIG.KW_ADD:
+                assert param_action_add(
+                    params
+                ), "Rule {rule} parameter action `add` do not have must exits attr."
+            elif params[CONFIG.ACTION] == CONFIG.KW_REMOVE:
+                assert param_action_remove(
+                    params
+                ), "Rule {rule} parameter action `remove` do not have must exits attr."
+            elif params[CONFIG.ACTION] == CONFIG.KW_REPLACE:
+                assert action_replace(
+                    params
+                ), "Rule {rule} parameter action `replace` do not have must exits attr."
+            else:
+                raise ValueError(
+                    "Rule {rule} parameter action must with specific value."
+                )
+
+
+def action_replace(param: Dict[str, Any]) -> bool:
+    return CONFIG.SOURCE in param and CONFIG.DESTINATION in param
+
+
+def param_action_add(param: Dict[str, Any]) -> bool:
+    return (
+        CONFIG.ARGUMENT in param
+        and CONFIG.DEFAULT in param
+        and CONFIG.TYPE in param[CONFIG.DEFAULT]
+        and CONFIG.VALUE in param[CONFIG.DEFAULT]
+    )
+
+
+def param_action_remove(param: Dict[str, Any]) -> bool:
+    return CONFIG.ARGUMENT in param


### PR DESCRIPTION
support three type of action(replace, add, remove) in both module and parameter of migration. Make the migration more flexible and for all kind of cases

```yaml
migration:
  module:
    - action: replace
      src: airflow.DAG
      dest: pydolphinscheduler.core.process_definition.ProcessDefinition
  parameter:
    - action: replace
      src: dag_id
      dest: name
```