### PR TITLE
fix: SetuptoolsDeprecationWarning due to PEP 420

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ platforms = any
 package_dir =
     =src
 packages =
-    find:
+    find_namespace:
 install_requires =
     libcst
     PyYaml


### PR DESCRIPTION
fix: #24
For more detail according to https://peps.python.org/pep-0420