### PR TITLE
feat: New rules airflow.DAG.schedule_interval migrate

### DIFF
--- a/src/airphin/constants.py
+++ b/src/airphin/constants.py
@@ -1,9 +1,12 @@
 class TOKEN:
     """Constants token for airphin."""
 
-    IMPORT: str = "import"
+    QUESTION: str = "?"
     COMMA: str = ","
     POINT: str = "."
+    SPACE: str = " "
+    ZERO: str = "0"
+    IMPORT: str = "import"
     STRING: str = "str"
     CODE: str = "code"
     NEW_LINE: str = "\n"
@@ -14,6 +17,9 @@ class KEYWORD:
 
     MIGRATE_MARK: str = "-airphin"
     WORKFLOW_SUBMIT: str = "submit"
+    AIRFLOW_DAG_SCHEDULE: str = "schedule_interval"
+    AIRFLOW_DAG: str = "airflow.DAG"
+    DEFAULT_SCHEDULE: str = "0 0 0 * * ? *"
 
 
 class REGEXP:
@@ -45,3 +51,10 @@ class CONFIG:
     DEFAULT: str = "default"
     TYPE: str = "type"
     VALUE: str = "value"
+
+
+class NUMBER:
+    """Constants number for airphin."""
+
+    SCHEDULE_TOTAL_NUM: int = 9
+    SCHEDULE_SPACE_NUM: int = 4

--- a/src/airphin/core/transformer/route.py
+++ b/src/airphin/core/transformer/route.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import warnings
-from typing import Set, Union
+from typing import List, Set, Union
 
 import libcst as cst
 import libcst.matchers as m
@@ -110,7 +110,7 @@ class Transformer(cst.CSTTransformer):
             self.have_submit_expr.add(original_node.value.func.value.value)
         return updated_node
 
-    def _build_submit_exprs(self) -> list[SimpleStatementLine]:
+    def _build_submit_exprs(self) -> List[SimpleStatementLine]:
         miss_alias = self.workflow_alias.difference(self.have_submit_expr)
         return [
             cst.parse_statement(f"{alias}.{KEYWORD.WORKFLOW_SUBMIT}()")

--- a/src/airphin/core/transformer/route.py
+++ b/src/airphin/core/transformer/route.py
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 import warnings
-from typing import List, Set, Union
+from typing import Set, Union
 
 import libcst as cst
 import libcst.matchers as m
-from libcst import BaseExpression, FlattenSentinel, RemovalSentinel
+from libcst import BaseExpression, FlattenSentinel, RemovalSentinel, SimpleStatementLine
 from libcst.metadata import PositionProvider, QualifiedName, QualifiedNameProvider
 
 from airphin.constants import KEYWORD
@@ -110,7 +110,7 @@ class Transformer(cst.CSTTransformer):
             self.have_submit_expr.add(original_node.value.func.value.value)
         return updated_node
 
-    def _build_submit_exprs(self) -> List[BaseExpression]:
+    def _build_submit_exprs(self) -> list[SimpleStatementLine]:
         miss_alias = self.workflow_alias.difference(self.have_submit_expr)
         return [
             cst.parse_statement(f"{alias}.{KEYWORD.WORKFLOW_SUBMIT}()")

--- a/src/airphin/rules/core/dagContext.yaml
+++ b/src/airphin/rules/core/dagContext.yaml
@@ -39,7 +39,7 @@ examples:
           name='dag',
           description='DAG description',
           start_time=datetime(2020, 1, 1),
-          schedule='@once',
+          schedule='0 0 0 * * ? *',
       )
   context:
     description: |
@@ -63,7 +63,7 @@ examples:
           name='dag',
           description='DAG description',
           start_time=datetime(2020, 1, 1),
-          schedule='@once',
+          schedule='0 0 0 * * ? *',
       ) as dag:
           pass
       dag.submit()

--- a/src/airphin/utils/string.py
+++ b/src/airphin/utils/string.py
@@ -1,0 +1,19 @@
+from airphin.constants import KEYWORD, NUMBER, TOKEN
+
+
+def convert_schedule(val: str) -> str:
+    """Convert airflow schedule string to dolphinscheduler's.
+
+    Will convert including:
+    * crontab schedule string from ``5 4 * * *`` to ```0 5 4 * * ? *``
+    * shortcut schedule string like ``@daily`` to ``0 0 0 * * ? *``.
+    """
+    if (
+        len(val) == NUMBER.SCHEDULE_TOTAL_NUM
+        and val.count(TOKEN.SPACE) == NUMBER.SCHEDULE_SPACE_NUM
+    ):
+        val_list = val.split(TOKEN.SPACE)
+        val_list.insert(0, TOKEN.ZERO)
+        val_list.insert(-1, TOKEN.QUESTION)
+        return TOKEN.SPACE.join(val_list)
+    return KEYWORD.DEFAULT_SCHEDULE


### PR DESCRIPTION
* crontab string migrate to dolphinscheduler's, ex: from `5 4 * * *`` to ```0 5 4 * * ? *``
* others migrate to dolphinscheduler default daily ``0 0 0 * * ? *``, include ``@daily`` and ``timedelta(days=1)``