### PR TITLE
fix: Miss auto add submit statement for not airflow.DAG

### DIFF
--- a/src/airphin/constants.py
+++ b/src/airphin/constants.py
@@ -19,6 +19,7 @@ class KEYWORD:
     WORKFLOW_SUBMIT: str = "submit"
     AIRFLOW_DAG_SCHEDULE: str = "schedule_interval"
     AIRFLOW_DAG: str = "airflow.DAG"
+    AIRFLOW_DAG_SIMPLE: str = "DAG"
     DEFAULT_SCHEDULE: str = "0 0 0 * * ? *"
 
 

--- a/src/airphin/core/transformer/route.py
+++ b/src/airphin/core/transformer/route.py
@@ -88,7 +88,11 @@ class Transformer(cst.CSTTransformer):
 
     def leave_WithItem_asname(self, node: cst.WithItem) -> None:
         """Get airflow Dags alias names."""
-        self.workflow_alias.add(node.asname.name.value)
+        if m.matches(node.item, m.Call()) and m.matches(
+            cst.ensure_type(node.item, cst.Call).func,
+            m.Name(value=KEYWORD.AIRFLOW_DAG_SIMPLE),
+        ):
+            self.workflow_alias.add(node.asname.name.value)
 
     def leave_Expr(
         self, original_node: cst.Expr, updated_node: cst.Expr

--- a/tests/rules/EdgeCases.yaml
+++ b/tests/rules/EdgeCases.yaml
@@ -47,3 +47,39 @@ test_cases:
           abc='def', 
       command="echo 'Airflow DummyOperator'"
       )
+  # have with itme but not airflow.DAG 
+  have_not_dag_with_item:
+    src: |
+      from contextlib import closing
+      from airflow.operators.python import PythonOperator
+      from airflow.providers.postgres.hooks.postgres import PostgresHook
+      
+      def demo():
+          connection = PostgresHook.get_connection('postgres_default')
+          hook = PostgresHook(connection=connection)
+          with closing(hook.get_conn()) as conn:
+              with closing(conn.cursor()) as cursor:
+                  cursor.execute('SELECT 1')
+                  print(cursor.fetchall())
+      
+      demo = PythonOperator(
+          task_id='demo',
+          python_callable=demo,
+      )
+    dest: |
+      from contextlib import closing
+      from pydolphinscheduler.tasks.python import Python
+      from airphin.fake.hooks.postgres import PostgresHook
+      
+      def demo():
+          connection = PostgresHook.get_connection('postgres_default')
+          hook = PostgresHook(connection=connection)
+          with closing(hook.get_conn()) as conn:
+              with closing(conn.cursor()) as cursor:
+                  cursor.execute('SELECT 1')
+                  print(cursor.fetchall())
+      
+      demo = Python(
+          name='demo',
+          definition=demo,
+      )


### PR DESCRIPTION
when we have with item not equal to airflow.DAG, airphin also add statement for ``submit`` method call. ex

before:

```py
with closing(hook.get_conn()) as conn:
    conn
```

after:

```py
with closing(hook.get_conn()) as conn:
    conn

conn.submit()
```

that is not correct, and this patch try to fix it